### PR TITLE
Fix: Extra Error Checking for Reformat Date

### DIFF
--- a/app.js
+++ b/app.js
@@ -128,7 +128,8 @@ hbs.handlebars.registerHelper("select", function (value, options) {
 // reformat date
 hbs.handlebars.registerHelper("reformat_date", function (value) {
   if (!value || !/^\d\d\/\d\d\/\d\d\d\d$/.test(value)) { return ""; }
-  return moment(value, "MM/DD/YY").format("YYYY-MM-DD");
+  const new_value = moment(value, "MM/DD/YY").format("YYYY-MM-DD");
+  return /^\d\d\d\d\-\d\d\-\d\d$/.test(new_value) ? new_value : "";
 });
 
 hbs.handlebars.registerHelper("isEmptyObject", function (obj) {


### PR DESCRIPTION
Made completely sure that reformat_date function won't pass in "Invalid Date" to value of date picker